### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint and Test (Node ${{ matrix.node-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/hirakinii/grdm-api-typescript/security/code-scanning/1](https://github.com/hirakinii/grdm-api-typescript/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including the existing `test` job).  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing functionality (checkout and CI commands) while documenting and enforcing least privilege. No imports, methods, or dependencies are needed—just YAML configuration in the workflow file near the top-level keys (`name`, `on`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
